### PR TITLE
Fix python pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -20,7 +20,7 @@ requirements:
     - poetry-core >=1.0.0
     - pip
   run:
-    - python {{ python_min }},<4.0
+    - python >={{ python_min }},<4.0
     - langchain-core >=0.3.49,<0.4.0
     - boto3 >=1.37.0
     - numpy >=1.0.0,<2.0.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Right now python is pinned to 3.9 preventing install with other python versions. Fixing to be >=3.9,<4.0
```
error    libmamba Could not solve for environment specs
    The following packages are incompatible
    ├─ langchain-aws 0.2.18  is installable and it requires
    │  └─ python 3.9,<4.0 , which can be installed;
    └─ pin-1 is not installable because it requires
       └─ python 3.11.* , which conflicts with any installable versions previously reported.
```
